### PR TITLE
fix: Router 组件类型错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-router": "5.0.1",
-    "@types/react-router-dom": "^4.3.2",
+    "@types/react-router-dom": "^5.3.3",
     "acorn": "^8.8.2",
     "amis-widget-cli": "^3.1.8",
     "monaco-editor-webpack-plugin": "6.0.0",


### PR DESCRIPTION
修复因 `@types` 包版本不一致导致的 TS 报错。

<img width="831" alt="Snipaste_2023-08-07_18-25-32" src="https://github.com/aisuda/amis-editor-demo/assets/70502828/4337d21a-e705-40ac-b164-75fb077ec5c1">
